### PR TITLE
docs(prd): mandate Vercel AI Gateway and AI SDK usage via Gateway

### DIFF
--- a/prd.md
+++ b/prd.md
@@ -25,9 +25,16 @@ JudgeGPT is a satirical, multi-agent hackathon judging system designed for the [
 ## 🛠 Tech Stack
 
 * **Agents & Automation**: Magnitude for browser-driven agent tests with vision.
-* **LLMs**: Claude 3.5 Sonnet (via Vercel AI Gateway) for planning, GPT-4o (via Vercel AI Gateway) for commentary, GPT-4.1 for backup.
+* **LLMs**: Claude 3.5 Sonnet for planning, GPT-4o for commentary, GPT-4.1 for backup **(all via Vercel AI Gateway; no direct provider calls)**.
 * **Frontend**: Next.js (Vercel deploy) + Tailwind for sleek UI.
 * **Leaderboard & Commentary**: Realtime scoring dashboard inspired by Steel.dev Leaderboard.
+
+## 🔒 AI Integration Policy
+
+- Vercel AI Gateway is the exclusive provider for all AI requests across all environments.
+- No direct calls to OpenAI, Anthropic, Google Gemini, or any other LLM API are allowed. All requests must route through the Gateway.
+- Model selection (e.g., Claude 3.5 Sonnet, GPT-4o) is expressed via model strings in code; routing, policies, failover, and observability are handled by the Gateway.
+- All client configurations must use the Gateway base URL and API key via environment variables.
 
 ---
 
@@ -35,9 +42,12 @@ JudgeGPT is a satirical, multi-agent hackathon judging system designed for the [
 
 ### 1. Vercel AI Gateway
 
-* Create a Gateway in Vercel dashboard → get Gateway URL + API key.
-* Example usage (Node.js):
+- Create a Gateway in the Vercel dashboard → obtain Gateway URL + API key.
+- Environment variables:
+  - AI_GATEWAY_API_KEY
+  - AI_GATEWAY_BASE_URL (e.g. https://gateway.ai.vercel.com/api/v1/&lt;team&gt;/&lt;gateway&gt;/openai)
 
+Example usage (OpenAI-compatible client):
 ```ts
 import OpenAI from "openai";
 
@@ -111,6 +121,18 @@ npm install @vercel/ai react-query tailwindcss
 * Hours 8–12: Build leaderboard UI.
 * Hours 13–16: Add biasometer + appeal.
 * Hours 17–20: Integrate models via Gateway.
+---
+## 🚫 Anti-Patterns and Enforcement
+
+- Do not call provider endpoints directly (e.g., api.openai.com, api.anthropic.com, generativelanguage.googleapis.com).
+- Do not use provider SDKs without setting baseURL to the Gateway.
+- Do not store or reference provider API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) in the app. Use AI_GATEWAY_API_KEY only.
+- All AI requests must reference AI_GATEWAY_BASE_URL and AI_GATEWAY_API_KEY from environment variables.
+
+Review checklist:
+- Search for “openai.com”, “anthropic.com”, “googleapis”, “gemini” in code/PRs → none should appear in request code.
+- Verify all AI clients use baseURL = AI Gateway and apiKey = AI_GATEWAY_API_KEY.
+
 * Hours 21–24: Polish demo + presentation.
 
 ---

--- a/prd.md
+++ b/prd.md
@@ -53,7 +53,7 @@ import OpenAI from "openai";
 
 const client = new OpenAI({
   apiKey: process.env.AI_GATEWAY_API_KEY,
-  baseURL: "https://gateway.ai.vercel.com/api/v1/<team>/<gateway>/openai"
+  baseURL: process.env.AI_GATEWAY_BASE_URL
 });
 
 const response = await client.chat.completions.create({
@@ -61,6 +61,26 @@ const response = await client.chat.completions.create({
   messages: [{ role: "user", content: "Judge this project harshly." }],
 });
 ```
+Example usage (Vercel AI SDK via Gateway):
+```ts
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+const gatewayOpenAI = openai({
+  apiKey: process.env.AI_GATEWAY_API_KEY!,
+  baseURL: process.env.AI_GATEWAY_BASE_URL,
+});
+
+const result = await generateText({
+  model: gatewayOpenAI("gpt-4o-mini"),
+  prompt: "Provide a brutally honest critique of this hackathon project.",
+});
+
+console.log(result.text);
+```
+
+
+
 
 ### 2. Magnitude Setup
 
@@ -104,6 +124,18 @@ npm install @vercel/ai react-query tailwindcss
 ```
 
 ---
+## 🚫 Anti-Patterns and Enforcement
+
+- Do not call provider endpoints directly (e.g., api.openai.com, api.anthropic.com, generativelanguage.googleapis.com).
+- Do not use provider SDKs without setting baseURL to the Gateway.
+- Do not store or reference provider API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.). Use AI_GATEWAY_API_KEY only.
+- All AI requests must reference AI_GATEWAY_BASE_URL and AI_GATEWAY_API_KEY from environment variables.
+
+Review checklist:
+- Search for “openai.com”, “anthropic.com”, “googleapis”, “gemini” in code/PRs → none should appear in request code.
+- Verify all AI clients use baseURL = AI Gateway and apiKey = AI_GATEWAY_API_KEY.
+
+---
 
 ## 👩‍⚖️ Core Features
 
@@ -121,22 +153,9 @@ npm install @vercel/ai react-query tailwindcss
 * Hours 8–12: Build leaderboard UI.
 * Hours 13–16: Add biasometer + appeal.
 * Hours 17–20: Integrate models via Gateway.
----
-## 🚫 Anti-Patterns and Enforcement
-
-- Do not call provider endpoints directly (e.g., api.openai.com, api.anthropic.com, generativelanguage.googleapis.com).
-- Do not use provider SDKs without setting baseURL to the Gateway.
-- Do not store or reference provider API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) in the app. Use AI_GATEWAY_API_KEY only.
-- All AI requests must reference AI_GATEWAY_BASE_URL and AI_GATEWAY_API_KEY from environment variables.
-
-Review checklist:
-- Search for “openai.com”, “anthropic.com”, “googleapis”, “gemini” in code/PRs → none should appear in request code.
-- Verify all AI clients use baseURL = AI Gateway and apiKey = AI_GATEWAY_API_KEY.
-
 * Hours 21–24: Polish demo + presentation.
 
 ---
-
 ## ✅ Success Criteria
 
 * Working demo with automated judging.
@@ -149,12 +168,12 @@ Review checklist:
 ## 🔗 References
 
 * [Hackathon](https://vercel.com/i/ai-gateway-hackathon)
-* [AI Gateway Docs](https://vercel.com/ai/gateway)
+* [AI Gateway Docs](https://vercel.com/docs/ai-gateway)
 * [Magnitude Quickstart](https://docs.magnitude.run/getting-started/introduction)
 * [Magnitude Test Setup](https://docs.magnitude.run/testing/test-setup)
 * [Steel.dev Leaderboard](https://leaderboard.steel.dev/)
 * [Web Eval Agent Repo](https://github.com/Operative-Sh/web-eval-agent)
-* [AI SDK Intro](https://vercel.com/docs/ai/vercel-ai-sdk)
+* [AI SDK Docs](https://vercel.com/docs/ai/vercel-ai-sdk)
 * [Anthropic Models](https://docs.anthropic.com/claude/docs/models-overview)
 * [OpenAI GPT‑4.1](https://openai.com/index/gpt-4-1/)
 * [Google Gemini 2.5 Pro](https://ai.google.dev/gemini-api/docs/models/gemini)


### PR DESCRIPTION
# docs(prd): mandate Vercel AI Gateway and AI SDK usage via Gateway

## Summary
Updated the JudgeGPT PRD to explicitly mandate Vercel AI Gateway as the exclusive AI provider across all environments. Added comprehensive usage examples, anti-patterns guidance, and environment variable configuration to ensure all AI requests route through the Gateway with no direct provider calls.

**Key changes:**
- Added "🔒 AI Integration Policy" section mandating Gateway-only usage
- Updated OpenAI client example to use environment variables for baseURL
- Added new Vercel AI SDK example showing Gateway routing pattern
- Added "🚫 Anti-Patterns and Enforcement" section with review checklist
- Updated reference links to canonical documentation URLs
- Clarified environment variable requirements (AI_GATEWAY_API_KEY, AI_GATEWAY_BASE_URL)

## Review & Testing Checklist for Human
- [ ] **Verify AI SDK example works**: Test the `generateText` with `openai()` provider routing through Gateway baseURL
- [ ] **Check environment variable names**: Confirm `AI_GATEWAY_API_KEY` and `AI_GATEWAY_BASE_URL` match Vercel's actual conventions
- [ ] **Validate Gateway URL format**: Verify the `https://gateway.ai.vercel.com/api/v1/<team>/<gateway>/openai` pattern is correct
- [ ] **Test reference links**: Click through updated documentation links (AI Gateway Docs, AI SDK Docs) to ensure they resolve correctly

### Notes
The TypeScript examples weren't tested locally, so human verification of the AI SDK routing pattern is especially important. The anti-patterns section aims to prevent direct provider API calls but may need refinement based on actual implementation experience.

**Link to Devin run**: https://app.devin.ai/sessions/b07e93ad5cc44a26b9e4749040b7c9e2  
**Requester**: pc-style (@pc-style)